### PR TITLE
[bug] Set direcotry as safe to prevent failure

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,8 @@ REPO_FULLNAME=$(jq -r ".repository.full_name" "$GITHUB_EVENT_PATH")
 
 echo "## Initializing git repo..."
 git init
+echo "## Setting this directory as safe..."
+git config --global --add safe.directory $(pwd)
 echo "### Adding git remote..."
 git remote add origin https://x-access-token:$ACCESS_TOKEN@github.com/$REPO_FULLNAME.git
 echo "### Getting branch"


### PR DESCRIPTION
The action started failing because of the following security fix in git:

https://github.blog/2022-04-12-git-security-vulnerability-announced/

The action creates a git repo in the current directory in order to checkout the upstream project but as the directory is docker mounted, it is detected by git as pertaining to another user and git fails adding the upstream remote.

This PR make git happy by telling him that the current directory is safe.

[This issue](https://github.com/actions/checkout/issues/760) helped me find what was happening.